### PR TITLE
Move access token to authorization header

### DIFF
--- a/src/controllers/tokenController.ts
+++ b/src/controllers/tokenController.ts
@@ -27,7 +27,14 @@ export const refreshToken = async (req: Request, res: Response) => {
 }
 
 export const validateToken = async (req: Request, res: Response) => {
-  const { accessToken } = req.body
+  const authHeader = req.headers.authorization
+
+  if (!authHeader || !authHeader.startsWith('Bearer ')) {
+    res.status(401).json({ message: 'Authorization header missing or malformed' })
+    return
+  }
+
+  const accessToken = authHeader.split(' ')[1]
   if (!accessToken) {
     res.status(400).json({ message: 'Access token not provided' })
     return
@@ -42,11 +49,14 @@ export const validateToken = async (req: Request, res: Response) => {
 }
 
 export const getEmail = async (req: Request, res: Response) => {
-  const accessToken = req.headers['authorization']
-  if (!accessToken || typeof accessToken != 'string') {
-    res.status(400).json({ message: 'Access token not provided' })
+  const authHeader = req.headers.authorization
+
+  if (!authHeader || !authHeader.startsWith('Bearer ')) {
+    res.status(401).json({ message: 'Authorization header missing or malformed' })
     return
   }
+
+  const accessToken = authHeader.split(' ')[1]
   try {
     const decoded = jwt.verify(accessToken, jwtSecret) as {
       data: string

--- a/test/token/validateToken.spec.ts
+++ b/test/token/validateToken.spec.ts
@@ -14,25 +14,39 @@ describe('a POST to /api/auth/validate', () => {
 
   it('should check if a token is correct', async () => {
     const data = {
-      accessToken: 'a working access token'
+      accessToken: 'aWorkingAccessToken'
     }
     sinon.stub(jwt, 'verify').resolves({ email: 'test@example.com' })
 
-    const res = await chai.request(app).post('/api/auth/validate').send(data)
+    const res = await chai
+      .request(app)
+      .post('/api/auth/validate')
+      .set('authorization', `Bearer ${data.accessToken}`)
     expect(res).to.have.status(200)
 
     sinon.restore()
     const badData = {
-      accessToken: 'an invalid access token'
+      accessToken: 'anInvalidAccessToken'
     }
     sinon.stub(jwt, 'verify').throws(new Error())
 
-    const badRes = await chai.request(app).post('/api/auth/validate').send(badData)
+    const badRes = await chai
+      .request(app)
+      .post('/api/auth/validate')
+      .set('authorization', `Bearer ${badData.accessToken}`)
     expect(badRes).to.have.status(401)
   })
 
   it('should fail in a controlled manner if the access token is not provided', async () => {
     const res = await chai.request(app).post('/api/auth/refresh')
     expect(res).to.have.status(400)
+  })
+
+  it('should fail in a controlled manner if the wrong type of access token is provided', async () => {
+    const res = await chai
+      .request(app)
+      .post('/api/auth/validate')
+      .set('authorization', 'NotBearer token')
+    expect(res).to.have.status(401)
   })
 })


### PR DESCRIPTION
Moved the access token location from the body of the request to a better suited authorization header.