### PR TITLE
avoid running deploy image outside main branch

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -57,7 +57,7 @@ jobs:
     runs-on: ubuntu-latest
     needs:
       - release
-    if: github.event_name != 'pull_request' # Skip during PRs
+    if: github.event_name != 'pull_request' && github.ref != 'refs/heads/main' # Skips if is PR or isn't inside main branch
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4


### PR DESCRIPTION
The docker image was being deployed when inside renovate branches, this change makes it so the deploy-image job only runs when inside the main branch.