### PR TITLE
move refresh token management to cookies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "license": "MIT",
       "dependencies": {
         "bcrypt": "^5.1.1",
+        "cookie-parser": "^1.4.6",
         "cors": "^2.8.5",
         "dotenv": "^16.4.5",
         "express": "^4.19.2",
@@ -25,6 +26,7 @@
         "@types/bcrypt": "^5.0.2",
         "@types/chai": "^4.3.17",
         "@types/chai-http": "^4.2.0",
+        "@types/cookie-parser": "^1.4.7",
         "@types/cors": "^2.8.17",
         "@types/eslint__js": "^8.42.3",
         "@types/express": "^4.17.21",
@@ -2052,6 +2054,15 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/cookie-parser": {
+      "version": "1.4.7",
+      "resolved": "https://registry.npmjs.org/@types/cookie-parser/-/cookie-parser-1.4.7.tgz",
+      "integrity": "sha512-Fvuyi354Z+uayxzIGCwYTayFKocfV7TuDYZClCdIP9ckhvAu/ixDtCB6qx2TT0FKjPLf1f3P/J1rgf6lPs64mw==",
+      "dev": true,
+      "dependencies": {
+        "@types/express": "*"
+      }
+    },
     "node_modules/@types/cookiejar": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@types/cookiejar/-/cookiejar-2.1.5.tgz",
@@ -3395,6 +3406,26 @@
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.6.0.tgz",
       "integrity": "sha512-U71cyTamuh1CRNCfpGY6to28lxvNwPG4Guz/EVjgf3Jmzv0vlDp1atT9eS5dDjMYHucpHbWns6Lwf3BKz6svdw==",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie-parser": {
+      "version": "1.4.6",
+      "resolved": "https://registry.npmjs.org/cookie-parser/-/cookie-parser-1.4.6.tgz",
+      "integrity": "sha512-z3IzaNjdwUC2olLIB5/ITd0/setiaFMLYiZJle7xg5Fe9KWAceil7xszYfHHBtDFYLSgJduS2Ty0P1uJdPDJeA==",
+      "dependencies": {
+        "cookie": "0.4.1",
+        "cookie-signature": "1.0.6"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/cookie-parser/node_modules/cookie": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.4.1.tgz",
+      "integrity": "sha512-ZwrFkGJxUR3EIoXtO+yVE69Eb7KlixbaeAWfBQB9vVsNn/o+Yw69gBWSSDK825hQNdN+wF8zELf3dFNl/kxkUA==",
       "engines": {
         "node": ">= 0.6"
       }

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "@types/bcrypt": "^5.0.2",
     "@types/chai": "^4.3.17",
     "@types/chai-http": "^4.2.0",
+    "@types/cookie-parser": "^1.4.7",
     "@types/cors": "^2.8.17",
     "@types/eslint__js": "^8.42.3",
     "@types/express": "^4.17.21",
@@ -67,6 +68,7 @@
   },
   "dependencies": {
     "bcrypt": "^5.1.1",
+    "cookie-parser": "^1.4.6",
     "cors": "^2.8.5",
     "dotenv": "^16.4.5",
     "express": "^4.19.2",

--- a/src/app.ts
+++ b/src/app.ts
@@ -1,5 +1,7 @@
 import express from 'express'
 import bodyParser from 'body-parser'
+import cookieParser from 'cookie-parser'
+
 import dotenv from 'dotenv'
 import connectDB from './config/database'
 import authRoutes from './routes/authRoutes'
@@ -11,6 +13,7 @@ connectDB()
 const app = express()
 
 app.use(bodyParser.json())
+app.use(cookieParser())
 
 const corsOptions = {
   origin: 'http://localhost:5173',

--- a/src/controllers/tokenController.ts
+++ b/src/controllers/tokenController.ts
@@ -1,10 +1,15 @@
 import { Request, Response } from 'express'
 import jwt from 'jsonwebtoken'
+import generateToken from '../utils/generateToken'
 
 export const jwtSecret = process.env.JWT_SECRET || 'testingsecret'
 
 export const refreshToken = async (req: Request, res: Response) => {
-  const { refreshToken } = req.body
+  if (!req.cookies) {
+    res.status(400).json({ message: 'Refresh token not provided' })
+    return
+  }
+  const refreshToken = req.cookies.refreshToken
 
   if (!refreshToken) {
     res.status(400).json({ message: 'Refresh token not provided' })
@@ -16,10 +21,7 @@ export const refreshToken = async (req: Request, res: Response) => {
     const decoded = jwt.verify(refreshToken, jwtSecret) as { data: string }
 
     // Issue a new access token
-    const newAccessToken = jwt.sign({ data: decoded.data }, jwtSecret, {
-      expiresIn: '15m'
-    })
-
+    const newAccessToken = generateToken(decoded.data, '15m')
     res.status(201).json({ accessToken: newAccessToken })
   } catch {
     res.status(401).json({ message: 'Invalid refresh token' })

--- a/test/token/refreshToken.spec.ts
+++ b/test/token/refreshToken.spec.ts
@@ -18,7 +18,10 @@ describe('a POST to /api/auth/refresh', () => {
     }
     sinon.stub(jwt, 'verify').resolves({ email: 'test@example.com' })
 
-    const res = await chai.request(app).post('/api/auth/refresh').send(data)
+    const res = await chai
+      .request(app)
+      .post('/api/auth/refresh')
+      .set('Cookie', `refreshToken=${data.refreshToken}`)
     expect(res).to.have.status(201)
   })
 
@@ -32,7 +35,10 @@ describe('a POST to /api/auth/refresh', () => {
       refreshToken: 'a broken refresh token'
     }
     sinon.stub(jwt, 'verify').throws(new Error())
-    const res = await chai.request(app).post('/api/auth/refresh').send(data)
+    const res = await chai
+      .request(app)
+      .post('/api/auth/refresh')
+      .set('Cookie', `refreshToken=${data.refreshToken}`)
     expect(res).to.have.status(401)
   })
 })


### PR DESCRIPTION
Moved refresh token management to cookies, allowing for a more streamlined management.