### PR TITLE
Add refresh token inside login and registration data

### DIFF
--- a/src/controllers/authController.ts
+++ b/src/controllers/authController.ts
@@ -27,7 +27,8 @@ export const registerUser = async (req: Request, res: Response) => {
       res.status(201).json({
         _id: user._id,
         email: user.email,
-        accessToken
+        accessToken,
+        refreshToken
       })
     } else {
       res.status(400).json({ message: 'Invalid user data' })
@@ -52,7 +53,8 @@ export const authUser = async (req: Request, res: Response) => {
       res.status(200).json({
         _id: user._id,
         email: user.email,
-        accessToken
+        accessToken,
+        refreshToken
       })
     } else {
       res.status(401).json({ message: 'Invalid email or password' })


### PR DESCRIPTION
For easier use, instead of having it only in the cookies the refresh token can now be accessed from the response data that get returned from a login request.